### PR TITLE
Fix: content-type and type= argument in <MIMEArgs> were not properly handled.

### DIFF
--- a/examples/mha-p7m
+++ b/examples/mha-p7m
@@ -87,7 +87,7 @@ $mhonarc::CBRawMessageBodyRead = sub {
     if ($sub_header->{'content-type'}) {
         # Make sure update mhonarc's meta field for content-type
         my $ctype = $sub_header->{'content-type'}[0];
-        if ($ctype =~ m%^\s*([\w\-\./]+)%) {
+        if ($ctype =~ m%^\s*([\w\!\#\$\&\-\^.+/]+)%) {
             $fields->{'x-mha-content-type'} = $1;
         }
     }

--- a/examples/mhasiteinit-p7m.pl
+++ b/examples/mhasiteinit-p7m.pl
@@ -86,7 +86,7 @@ $mhonarc::CBRawMessageBodyRead = sub {
     if ($sub_header->{'content-type'}) {
         # Make sure update mhonarc's meta field for content-type
         my $ctype = $sub_header->{'content-type'}[0];
-        if ($ctype =~ m%^\s*([\w\-\./]+)%) {
+        if ($ctype =~ m%^\s*([\w\!\#\$\&\-\^.+/]+)%) {
             $fields->{'x-mha-content-type'} = $1;
         }
     }

--- a/lib/mhamain.pl
+++ b/lib/mhamain.pl
@@ -959,7 +959,8 @@ sub read_mail_header {
     ## Get Content-Type ##
     ##------------------##
     if (defined($fields->{'content-type'})) {
-        ($ctype = $fields->{'content-type'}[0]) =~ m%^\s*([\w\-\./]+)%;
+        ($ctype = $fields->{'content-type'}[0]) =~
+            m%^\s*([\w\!\#\$\&\-\^.+/]+)%;
         $ctype = lc($1 || 'text/plain');
     } else {
         $ctype = 'text/plain';

--- a/lib/mhexternal.pl
+++ b/lib/mhexternal.pl
@@ -112,7 +112,6 @@ sub filter {
     $args = '' unless defined($args);
     my $name       = '';
     my $ctype      = '';
-    my $type       = '';
     my $inline     = 0;
     my $inext      = '';
     my $intype     = '';
@@ -136,10 +135,10 @@ sub filter {
 
     ## Get content-type
     if (!defined($ctype = $fields->{'x-mha-content-type'})) {
-        ($ctype) = $fields->{'content-type'}[0] =~ m%^\s*([\w\-\./]+)%;
+        ($ctype) =
+            $fields->{'content-type'}[0] =~ m%^\s*([\w\!\#\$\&\-\^.+/]+)%;
         $ctype =~ tr/A-Z/a-z/;
     }
-    $type = (mhonarc::get_mime_ext($ctype))[1];
 
     ## Get disposition
     my ($disp, $nameparm, $raw_name, $html_name) =
@@ -172,6 +171,7 @@ sub filter {
     ## Check if extension and type description passed in
     if ($args =~ /\bext=(\S+)/i) { $inext = $1; $inext =~ s/['"]//g; }
     if ($args =~ /\btype="([^"]+)"/i) { $intype = $1; }
+    $intype ||= (mhonarc::get_mime_ext($ctype))[1];
 
     ## Check if utilizing extension from mail header defined filename
     if ($dispext && $usenameext) {
@@ -229,8 +229,11 @@ INLINESW: {
             . mhonarc::htmlize($fields->{'content-description'}[0])
             . "</p>\n"
             if (defined $fields{'content-description'});
-        $ret .= qq|<p><a href="$urlfile" $target><img src="$urlfile" |
-            . qq|alt="$type"></a></p>\n|;
+        $ret .=
+              qq|<p><a href="$urlfile" $target><img src="$urlfile" |
+            . qq|alt="|
+            . mhonarc::htmlize($intype)
+            . qq|"></a></p>\n|;
 
     } else {
         my $is_mesg = $ctype =~ /^message\//;
@@ -242,8 +245,8 @@ INLINESW: {
             $namelabel = readmail::MAILdecode_1522_str($1);
             $desc .= 'Message attachment';
         } else {
-            $desc .= mhonarc::htmlize($fields->{'content-description'}[0])
-                || $type;
+            $desc .= mhonarc::htmlize($fields->{'content-description'}[0]
+                    || $intype);
             if ($nameparm) {
                 #$namelabel = mhonarc::htmlize($nameparm);
                 $namelabel = $html_name;

--- a/lib/mhmimetypes.pl
+++ b/lib/mhmimetypes.pl
@@ -315,7 +315,7 @@ sub write_attachment {
     }
 
     my $ctype = 'application/octet-stream';
-    if ($content =~ m%^\s*([\w\-\./]+)%) {
+    if ($content =~ m%^\s*([\w\!\#\$\&\-\^.+/]+)%) {
         $ctype = $1;
     }
 

--- a/lib/mhnull.pl
+++ b/lib/mhnull.pl
@@ -34,7 +34,8 @@ package m2h_null;
 
 sub filter {
     my ($fields, $data, $isdecode, $args) = @_;
-    my ($ctype) = $fields->{'content-type'}[0] =~ m%^\s*([\w\-\./]+)%;
+    my ($ctype) =
+        $fields->{'content-type'}[0] =~ m%^\s*([\w\!\#\$\&\-\^.+/]+)%;
     my ($disp, $nameparm, $raw_name, $html_name) =
         readmail::MAILhead_get_disposition($fields, 1);
     join("",

--- a/lib/mhtxtenrich.pl
+++ b/lib/mhtxtenrich.pl
@@ -85,7 +85,8 @@ sub filter {
     $args = "" unless defined($args);
 
     ## Get content-type
-    my ($ctype) = $fields->{'content-type'}[0] =~ m%^\s*([\w\-\./]+)%;
+    my ($ctype) =
+        $fields->{'content-type'}[0] =~ m%^\s*([\w\!\#\$\&\-\^.+/]+)%;
     my $richtext = $ctype =~ /\btext\/richtext\b/i;
 
     if (defined($charcnv) && defined(&$charcnv)) {

--- a/lib/mhtxthtml.pl
+++ b/lib/mhtxthtml.pl
@@ -451,7 +451,7 @@ sub resolve_cid {
     my $ctype = $href->{'fields'}{'x-mha-content-type'};
     if (!defined($ctype)) {
         $ctype = $href->{'fields'}{'content-type'}[0];
-        ($ctype) = $ctype =~ m{^\s*([\w\-\./]+)};
+        ($ctype) = $ctype =~ m%^\s*([\w\!\#\$\&\-\^.+/]+)%;
     }
     return "" if readmail::MAILis_excluded($ctype);
 

--- a/lib/readmail.pl
+++ b/lib/readmail.pl
@@ -505,8 +505,9 @@ sub MAILread_body {
         $content = $fields->{'content-type'}->[0];
     }
     $content = 'text/plain' unless $content;
-    ($ctype) = $content =~ m%^\s*([\w\-\./]+)%;    # Extract content-type
-    $ctype =~ tr/A-Z/a-z/;                         # Convert to lowercase
+    ($ctype) =
+        $content =~ m%^\s*([\w\!\#\$\&\-\^.+/]+)%;    # Extract content-type
+    $ctype =~ tr/A-Z/a-z/;                            # Convert to lowercase
     if ($ctype =~ m%/%) {    # Extract base and sub types
         ($type, $subtype) = split(/\//, $ctype, 2);
     } elsif ($ctype =~ /text/i) {
@@ -1293,10 +1294,10 @@ sub extract_ctype {
         return 'text/plain';
     }
     if (ref($_[0])) {
-        $_[0][0] =~ m|^\s*([\w\-\./]+)|;
+        $_[0][0] =~ m%^\s*([\w\!\#\$\&\-\^.+/]+)%;
         return lc($1);
     }
-    $_[0] =~ m|^\s*([\w\-\./]+)|;
+    $_[0] =~ m%^\s*([\w\!\#\$\&\-\^.+/]+)%;
     lc($1);
 }
 


### PR DESCRIPTION
-   Correct regexps to contain characters defined in RFC6838, section 4.2.
-   `type=` argument was really not used.