### PR TITLE
bug #42323, Author Sort Secondary Sort is Wrong (#20)

### DIFF
--- a/lib/mhutil.pl
+++ b/lib/mhutil.pl
@@ -282,7 +282,7 @@ sub sort_messages {
         } else {
             return sort {
                        ($from{$a} cmp $from{$b})
-                    || ($Time{$a} <=> $Time{$a})
+                    || ($Time{$a} <=> $Time{$b})
             } keys %Subject;
         }
 


### PR DESCRIPTION
https://savannah.nongnu.org/bugs/?42323

This may fix #20.
